### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Set Version
       shell: bash
-      run: echo "::set-output name=version::$(./bin/cohctl version | grep 'CLI Version:' | awk '{print $3}')"
+      run: echo "version=$(./bin/cohctl version | grep 'CLI Version:' | awk '{print $3}')" >> "$GITHUB_OUTPUT"
       id: version
 
     - name: E2E Local Tests


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter