### PR TITLE
The CLI should correctly use the http proxy environment variables

### DIFF
--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -505,25 +505,16 @@ func (b *ByteArraySink) AppendByteArray(bytes []byte) {
 // GetURLContents returns the contents at the given url as a []byte.
 func GetURLContents(resourceURL string) ([]byte, error) {
 	var (
-		err       error
-		req       *http.Request
-		resp      *http.Response
-		body      []byte
-		buffer    bytes.Buffer
-		URL       = url.URL{}
-		httpProxy = os.Getenv("HTTP_PROXY")
+		err    error
+		req    *http.Request
+		resp   *http.Response
+		body   []byte
+		buffer bytes.Buffer
 	)
 	cookies, _ := cookiejar.New(nil)
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: false, MinVersion: tls.VersionTLS12},
-	}
-
-	if httpProxy != "" {
-		proxy, err := URL.Parse(httpProxy)
-		if err != nil {
-			return body, errors.New("unable to parse HTTP_PROXY environment variable")
-		}
-		tr.Proxy = http.ProxyURL(proxy)
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	client := &http.Client{Transport: tr,

--- a/pkg/fetcher/http_fetcher.go
+++ b/pkg/fetcher/http_fetcher.go
@@ -1247,9 +1247,6 @@ func httpRequest(h HTTPFetcher, requestType, urlAppend string, absolute bool, co
 		body            []byte
 		unsanitizedBody []byte
 		buffer          bytes.Buffer
-		URL             = url.URL{}
-		httpProxy       = os.Getenv("HTTP_PROXY")
-		proxy           *url.URL
 		isJSON          = true
 	)
 
@@ -1300,19 +1297,11 @@ func httpRequest(h HTTPFetcher, requestType, urlAppend string, absolute bool, co
 	cookies, _ := cookiejar.New(nil)
 
 	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: IgnoreInvalidCerts, //nolint
 			Certificates:       certificates,
 			RootCAs:            certPool},
-	}
-
-	if httpProxy != "" {
-		proxy, err = URL.Parse(httpProxy)
-		if err != nil {
-			return constants.EmptyByte, fmt.Errorf("unable to parse HTTP_PROXY environment variable: %s, %v", httpProxy, err)
-		}
-		tr.Proxy = http.ProxyURL(proxy)
-		Logger.Info("Using HTTP Proxy", []zapcore.Field{zap.String("URL", httpProxy)}...)
 	}
 
 	client := &http.Client{Transport: tr,


### PR DESCRIPTION
The code that sets up the http transport directly reads the `HTTP_PROXY` environment variable to configure a proxy. This is not correct as it ignores things like `NO_PROXY`. There is a built in way to create a proxy which should be used.