### PR TITLE
Fix Trivy Jackson findings

### DIFF
--- a/templates/micronaut/pom.xml
+++ b/templates/micronaut/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <coherence.group.id>com.oracle.coherence.ce</coherence.group.id>
     <coherence.version>15.1.1-0-1</coherence.version>
-    <jackson.version>2.21.1</jackson.version>
+    <jackson.version>2.21.5</jackson.version>
     <java.version>21</java.version>
 
     <!-- Micronaut properties -->


### PR DESCRIPTION
## Summary

- update the Micronaut template Jackson version from 2.21.1 to 2.21.5
- resolve CVE-2026-54512 through CVE-2026-54518 reported by the post-merge Trivy scan

## Verification

- mvn -f templates/micronaut/pom.xml -DskipTests package
- dependency tree resolves jackson-databind 2.21.5 and Logback 1.5.35

Signed-off-by: Vaso Putica <vaso.putica@oracle.com>